### PR TITLE
feat: add responses API endpoints

### DIFF
--- a/apps/backend/src/routes/containers.ts
+++ b/apps/backend/src/routes/containers.ts
@@ -164,10 +164,9 @@ containerFilesRouter.post('/', async (req: Request, res: Response, next: NextFun
 containerFilesRouter.get('/:fileId', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const client = getOpenAIClient();
-    const file = await client.containers.files.retrieve(
-      req.params.containerId,
-      req.params.fileId,
-    );
+    const file = await client.containers.files.retrieve(req.params.fileId, {
+      container_id: req.params.containerId,
+    });
 
     res.json(file);
   } catch (error) {
@@ -178,10 +177,9 @@ containerFilesRouter.get('/:fileId', async (req: Request, res: Response, next: N
 containerFilesRouter.get('/:fileId/content', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const client = getOpenAIClient();
-    const response = await client.containers.files.content.retrieve(
-      req.params.containerId,
-      req.params.fileId,
-    );
+    const response = await client.containers.files.content.retrieve(req.params.fileId, {
+      container_id: req.params.containerId,
+    });
 
     const arrayBuffer = await response.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
@@ -199,7 +197,9 @@ containerFilesRouter.get('/:fileId/content', async (req: Request, res: Response,
 containerFilesRouter.delete('/:fileId', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const client = getOpenAIClient();
-    await client.containers.files.delete(req.params.containerId, req.params.fileId);
+    await client.containers.files.delete(req.params.fileId, {
+      container_id: req.params.containerId,
+    });
 
     res.status(204).send();
   } catch (error) {

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -3,12 +3,14 @@ import { Router } from 'express';
 import { containersRouter } from './containers.js';
 import { filesRouter } from './files.js';
 import { healthRouter } from './health.js';
+import { responsesRouter } from './responses.js';
 
 export const apiRouter = Router();
 
 apiRouter.use('/health', healthRouter);
 apiRouter.use('/files', filesRouter);
 apiRouter.use('/containers', containersRouter);
+apiRouter.use('/responses', responsesRouter);
 
 apiRouter.get('/', (_req, res) => {
   res.json({
@@ -17,6 +19,7 @@ apiRouter.get('/', (_req, res) => {
       health: '/api/health',
       files: '/api/files',
       containers: '/api/containers',
+      responses: '/api/responses',
     },
   });
 });

--- a/apps/backend/src/routes/responses.ts
+++ b/apps/backend/src/routes/responses.ts
@@ -1,0 +1,145 @@
+import type { NextFunction, Request, Response } from 'express';
+import { Router } from 'express';
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseRetrieveParamsNonStreaming,
+} from 'openai/resources/responses/responses';
+import type { InputItemListParams } from 'openai/resources/responses/input-items';
+
+import { getOpenAIClient } from '../lib/openaiClient.js';
+import { extractBoolean, extractNumber, extractString, extractStringArray } from './utils.js';
+
+const toResponseRetrieveParams = (query: Request['query']): ResponseRetrieveParamsNonStreaming => {
+  const params: ResponseRetrieveParamsNonStreaming = { stream: false };
+
+  const include = extractStringArray(query.include);
+  if (include) {
+    params.include = include as ResponseRetrieveParamsNonStreaming['include'];
+  }
+
+  const includeObfuscation = extractBoolean(query.include_obfuscation);
+  if (typeof includeObfuscation === 'boolean') {
+    params.include_obfuscation = includeObfuscation;
+  }
+
+  const startingAfter = extractNumber(query.starting_after);
+  if (typeof startingAfter === 'number' && startingAfter >= 0) {
+    params.starting_after = startingAfter;
+  }
+
+  return params;
+};
+
+const toInputItemListParams = (query: Request['query']): InputItemListParams => {
+  const params: InputItemListParams = {};
+
+  const include = extractStringArray(query.include);
+  if (include) {
+    params.include = include as InputItemListParams['include'];
+  }
+
+  const order = extractString(query.order);
+  if (order === 'asc' || order === 'desc') {
+    params.order = order;
+  }
+
+  const after = extractString(query.after);
+  if (after) {
+    params.after = after;
+  }
+
+  const limit = extractNumber(query.limit);
+  if (typeof limit === 'number' && limit > 0) {
+    params.limit = limit;
+  }
+
+  return params;
+};
+
+export const responsesRouter = Router();
+const responseInputItemsRouter = Router({ mergeParams: true });
+
+responsesRouter.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
+      return res.status(400).json({ error: 'Request body must be a JSON object.' });
+    }
+
+    const rawBody = req.body as Record<string, unknown>;
+    const streamFlag = extractBoolean(rawBody.stream);
+    if (streamFlag === true) {
+      return res.status(400).json({ error: 'Streaming responses are not supported by this endpoint.' });
+    }
+
+    const { stream: _ignored, ...rest } = rawBody;
+    const createParams: ResponseCreateParamsNonStreaming = {
+      ...(rest as ResponseCreateParamsNonStreaming),
+      stream: false,
+    };
+
+    const client = getOpenAIClient();
+    const response = await client.responses.create(createParams);
+
+    res.status(201).json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+responsesRouter.get('/:responseId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const stream = extractBoolean(req.query.stream);
+    if (stream === true) {
+      return res.status(400).json({ error: 'Streaming responses are not supported by this endpoint.' });
+    }
+
+    const params = toResponseRetrieveParams(req.query);
+
+    const client = getOpenAIClient();
+    const response = await client.responses.retrieve(req.params.responseId, params);
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+responsesRouter.delete('/:responseId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const client = getOpenAIClient();
+    await client.responses.delete(req.params.responseId);
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+responsesRouter.post('/:responseId/cancel', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const client = getOpenAIClient();
+    const response = await client.responses.cancel(req.params.responseId);
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+responsesRouter.use('/:responseId/input-items', responseInputItemsRouter);
+
+responseInputItemsRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const params = toInputItemListParams(req.query);
+
+    const client = getOpenAIClient();
+    const items = await client.responses.inputItems.list(
+      req.params.responseId,
+      Object.keys(params).length > 0 ? params : undefined,
+    );
+
+    res.json(items);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/backend/src/routes/utils.ts
+++ b/apps/backend/src/routes/utils.ts
@@ -36,3 +36,24 @@ export const extractStringArray = (value: unknown): string[] | undefined => {
 
   return undefined;
 };
+
+export const extractBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const candidate = extractString(value);
+  if (!candidate) {
+    return undefined;
+  }
+
+  if (candidate.toLowerCase() === 'true') {
+    return true;
+  }
+
+  if (candidate.toLowerCase() === 'false') {
+    return false;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary
- add a responses router to proxy create, retrieve, cancel, and delete operations to the OpenAI Responses API and expose input item listing
- mount the responses router under `/api/responses` and document it in the API root response
- add a boolean query helper and update container file routes to use the latest OpenAI client signatures

## Testing
- npm run build --prefix apps/backend

------
https://chatgpt.com/codex/tasks/task_e_68d94155fed48321958f68f99cde5bd3