### PR TITLE
Add HTTP API integration tests and share Express app setup

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -26,6 +27,7 @@
     "@types/ws": "^8.5.10",
     "tslib": "^2.6.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import morgan from 'morgan';
+
+import { env } from './config/env.js';
+import { apiRouter } from './routes/index.js';
+import { openaiWebhookRouter } from './routes/webhooks.js';
+
+export const createApp = () => {
+  const app = express();
+
+  app.use(helmet());
+  app.use(cors({ origin: env.corsOrigin }));
+  app.use('/webhooks/openai', express.raw({ type: 'application/json' }), openaiWebhookRouter);
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use(morgan('dev'));
+
+  app.get('/', (_req, res) => {
+    res.json({ message: 'Welcome to the Legendary Dollop API' });
+  });
+
+  app.use('/api', apiRouter);
+
+  app.use((req, res) => {
+    res.status(404).json({ error: 'Not Found', path: req.path });
+  });
+
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  });
+
+  return app;
+};

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,37 +1,8 @@
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import morgan from 'morgan';
-
+import { createApp } from './app.js';
 import { env } from './config/env.js';
-import { apiRouter } from './routes/index.js';
-import { openaiWebhookRouter } from './routes/webhooks.js';
 import { initializeWebSocketServer, shutdownWebSocketServer } from './lib/websocket.js';
 
-const app = express();
-
-app.use(helmet());
-app.use(cors({ origin: env.corsOrigin }));
-app.use('/webhooks/openai', express.raw({ type: 'application/json' }), openaiWebhookRouter);
-
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-app.use(morgan('dev'));
-
-app.get('/', (_req, res) => {
-  res.json({ message: 'Welcome to the Legendary Dollop API' });
-});
-
-app.use('/api', apiRouter);
-
-app.use((req, res) => {
-  res.status(404).json({ error: 'Not Found', path: req.path });
-});
-
-app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  console.error(err);
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+const app = createApp();
 
 const server = app.listen(env.port, () => {
   console.log(`API server listening on http://localhost:${env.port}`);

--- a/apps/backend/src/lib/websocket.test.ts
+++ b/apps/backend/src/lib/websocket.test.ts
@@ -16,14 +16,20 @@ beforeEach(async () => {
   server = createServer();
 
   await new Promise<void>((resolve, reject) => {
-    server.listen(0, (error?: Error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
+    const handleError = (error: Error) => {
+      server.off('listening', handleListening);
+      reject(error);
+    };
 
+    const handleListening = () => {
+      server.off('error', handleError);
       resolve();
-    });
+    };
+
+    server.once('error', handleError);
+    server.once('listening', handleListening);
+
+    server.listen(0);
   });
 
   initializeWebSocketServer(server);

--- a/apps/backend/src/lib/websocket.test.ts
+++ b/apps/backend/src/lib/websocket.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server as HttpServer } from 'http';
+import { WebSocket } from 'ws';
+
+import {
+  initializeWebSocketServer,
+  shutdownWebSocketServer,
+  broadcastResponseEvent,
+} from './websocket.js';
+import type { ResponseWebhookEvent } from './openaiWebhookEvents.js';
+
+let server: HttpServer;
+let port: number;
+
+beforeEach(async () => {
+  server = createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, (error?: Error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  initializeWebSocketServer(server);
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to determine server port');
+  }
+
+  port = address.port;
+});
+
+afterEach(async () => {
+  await shutdownWebSocketServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+});
+
+describe('WebSocket server', () => {
+  it('sends a connection established event when a client connects', async () => {
+    await new Promise<void>((resolve, reject) => {
+      const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+
+      client.once('error', reject);
+
+      client.once('message', (raw) => {
+        try {
+          const payload = JSON.parse(raw.toString());
+          expect(payload.type).toBe('connection.established');
+          expect(payload.data).toHaveProperty('timestamp');
+          client.close();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  });
+
+  it('broadcasts response status events to connected clients', async () => {
+    await new Promise<void>((resolve, reject) => {
+      const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+
+      client.once('error', reject);
+
+      client.on('message', (raw) => {
+        try {
+          const payload = JSON.parse(raw.toString());
+
+          if (payload.type === 'connection.established') {
+            const webhookEvent = {
+              type: 'response.completed',
+              data: { id: 'resp_123' },
+            } as ResponseWebhookEvent;
+
+            broadcastResponseEvent(webhookEvent);
+            return;
+          }
+
+          expect(payload.type).toBe('response.status');
+          expect(payload.data).toMatchObject({
+            responseId: 'resp_123',
+            eventType: 'response.completed',
+            status: 'completed',
+          });
+
+          client.close();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  });
+});

--- a/apps/backend/src/routes/api.test.ts
+++ b/apps/backend/src/routes/api.test.ts
@@ -1,0 +1,468 @@
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import OpenAI from 'openai';
+
+import { createApp } from '../app.js';
+
+const filesListMock = vi.fn();
+const filesCreateMock = vi.fn();
+const filesRetrieveMock = vi.fn();
+const filesContentMock = vi.fn();
+const filesDeleteMock = vi.fn();
+
+const containerListMock = vi.fn();
+const containerCreateMock = vi.fn();
+const containerRetrieveMock = vi.fn();
+const containerDeleteMock = vi.fn();
+
+const containerFilesListMock = vi.fn();
+const containerFilesCreateMock = vi.fn();
+const containerFilesRetrieveMock = vi.fn();
+const containerFilesContentRetrieveMock = vi.fn();
+const containerFilesDeleteMock = vi.fn();
+
+const responsesCreateMock = vi.fn();
+const responsesRetrieveMock = vi.fn();
+const responsesDeleteMock = vi.fn();
+const responsesCancelMock = vi.fn();
+const responseInputItemsListMock = vi.fn();
+
+const mockClient = {
+  files: {
+    list: filesListMock,
+    create: filesCreateMock,
+    retrieve: filesRetrieveMock,
+    content: filesContentMock,
+    delete: filesDeleteMock,
+  },
+  containers: {
+    list: containerListMock,
+    create: containerCreateMock,
+    retrieve: containerRetrieveMock,
+    delete: containerDeleteMock,
+    files: {
+      list: containerFilesListMock,
+      create: containerFilesCreateMock,
+      retrieve: containerFilesRetrieveMock,
+      content: {
+        retrieve: containerFilesContentRetrieveMock,
+      },
+      delete: containerFilesDeleteMock,
+    },
+  },
+  responses: {
+    create: responsesCreateMock,
+    retrieve: responsesRetrieveMock,
+    delete: responsesDeleteMock,
+    cancel: responsesCancelMock,
+    inputItems: {
+      list: responseInputItemsListMock,
+    },
+  },
+};
+
+vi.mock('../lib/openaiClient.js', () => ({
+  getOpenAIClient: vi.fn(() => mockClient),
+}));
+
+describe('HTTP API endpoints', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(() => {
+    process.env.OPENAI_API_KEY = 'test-api-key';
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    filesListMock.mockResolvedValue({ data: [] });
+    filesCreateMock.mockResolvedValue({ id: 'file_123' });
+    filesRetrieveMock.mockResolvedValue({ id: 'file_123' });
+    filesContentMock.mockResolvedValue({
+      arrayBuffer: async () => Buffer.from('file-content'),
+      headers: new Headers({ 'content-type': 'text/plain' }),
+    });
+    filesDeleteMock.mockResolvedValue({ id: 'file_123', deleted: true });
+
+    containerListMock.mockResolvedValue({ data: [] });
+    containerCreateMock.mockResolvedValue({ id: 'container_123' });
+    containerRetrieveMock.mockResolvedValue({ id: 'container_123' });
+    containerDeleteMock.mockResolvedValue(undefined);
+
+    containerFilesListMock.mockResolvedValue({ data: [] });
+    containerFilesCreateMock.mockResolvedValue({ id: 'container_file_123' });
+    containerFilesRetrieveMock.mockResolvedValue({ id: 'container_file_123' });
+    containerFilesContentRetrieveMock.mockResolvedValue({
+      arrayBuffer: async () => Buffer.from('container-file'),
+      headers: new Headers({ 'content-type': 'text/plain' }),
+    });
+    containerFilesDeleteMock.mockResolvedValue(undefined);
+
+    responsesCreateMock.mockResolvedValue({ id: 'resp_123' });
+    responsesRetrieveMock.mockResolvedValue({ id: 'resp_123' });
+    responsesDeleteMock.mockResolvedValue(undefined);
+    responsesCancelMock.mockResolvedValue({ id: 'resp_123', status: 'cancelled' });
+    responseInputItemsListMock.mockResolvedValue({ data: [] });
+
+    const app = createApp();
+
+    await new Promise<void>((resolve, reject) => {
+      server = app.listen(0, (error?: Error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Unable to determine server address for tests');
+    }
+
+    baseUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('returns a welcome message at the root route', async () => {
+    const response = await fetch(`${baseUrl}/`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Welcome to the Legendary Dollop API',
+    });
+  });
+
+  it('exposes the API index with the expected endpoints', async () => {
+    const response = await fetch(`${baseUrl}/api`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      message: 'API root',
+      endpoints: {
+        health: '/api/health',
+        files: '/api/files',
+        containers: '/api/containers',
+        responses: '/api/responses',
+      },
+    });
+  });
+
+  it('returns server health information', async () => {
+    const response = await fetch(`${baseUrl}/api/health`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe('ok');
+    expect(typeof payload.uptimeMs).toBe('number');
+    expect(typeof payload.timestamp).toBe('string');
+  });
+
+  it('lists files using sanitized query parameters', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/files?order=asc&purpose=assistants&after=file_42&limit=5`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(filesListMock).toHaveBeenCalledWith({
+      order: 'asc',
+      purpose: 'assistants',
+      after: 'file_42',
+      limit: 5,
+    });
+  });
+
+  it('creates a file upload from base64 content', async () => {
+    const toFileSpy = vi.spyOn(OpenAI, 'toFile').mockResolvedValue('upload-token' as never);
+
+    try {
+      const response = await fetch(`${baseUrl}/api/files`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          filename: 'notes.txt',
+          purpose: 'assistants',
+          content: Buffer.from('hello world').toString('base64'),
+          mimeType: 'text/plain',
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(filesCreateMock).toHaveBeenCalledWith({
+        file: 'upload-token',
+        purpose: 'assistants',
+      });
+    } finally {
+      toFileSpy.mockRestore();
+    }
+  });
+
+  it('rejects invalid file creation requests', async () => {
+    const response = await fetch(`${baseUrl}/api/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ purpose: 'assistants', content: '' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(filesCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('retrieves a file by id', async () => {
+    const response = await fetch(`${baseUrl}/api/files/file_123`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(filesRetrieveMock).toHaveBeenCalledWith('file_123');
+    expect(payload).toEqual({ id: 'file_123' });
+  });
+
+  it('returns file content as a base64 encoded payload', async () => {
+    const response = await fetch(`${baseUrl}/api/files/file_123/content`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(filesContentMock).toHaveBeenCalledWith('file_123');
+    expect(payload).toEqual({
+      id: 'file_123',
+      contentType: 'text/plain',
+      base64: Buffer.from('file-content').toString('base64'),
+    });
+  });
+
+  it('deletes a file by id', async () => {
+    const response = await fetch(`${baseUrl}/api/files/file_123`, { method: 'DELETE' });
+
+    expect(response.status).toBe(200);
+    expect(filesDeleteMock).toHaveBeenCalledWith('file_123');
+  });
+
+  it('lists containers with sanitized query params', async () => {
+    const response = await fetch(`${baseUrl}/api/containers?order=desc&after=cont_1&limit=3`);
+
+    expect(response.status).toBe(200);
+    expect(containerListMock).toHaveBeenCalledWith({
+      order: 'desc',
+      after: 'cont_1',
+      limit: 3,
+    });
+  });
+
+  it('creates a new container', async () => {
+    const response = await fetch(`${baseUrl}/api/containers`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'My Container',
+        fileIds: ['file_1', 'file_2'],
+        expiresAfter: { anchor: 'last_active_at', minutes: 10 },
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(containerCreateMock).toHaveBeenCalledWith({
+      name: 'My Container',
+      file_ids: ['file_1', 'file_2'],
+      expires_after: { anchor: 'last_active_at', minutes: 10 },
+    });
+  });
+
+  it('retrieves a container by id', async () => {
+    const response = await fetch(`${baseUrl}/api/containers/container_123`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(containerRetrieveMock).toHaveBeenCalledWith('container_123');
+    expect(payload).toEqual({ id: 'container_123' });
+  });
+
+  it('deletes a container by id', async () => {
+    const response = await fetch(`${baseUrl}/api/containers/container_123`, { method: 'DELETE' });
+
+    expect(response.status).toBe(204);
+    expect(containerDeleteMock).toHaveBeenCalledWith('container_123');
+  });
+
+  it('lists files within a container', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/containers/container_123/files?order=asc&after=file_1&limit=2`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(containerFilesListMock).toHaveBeenCalledWith('container_123', {
+      order: 'asc',
+      after: 'file_1',
+      limit: 2,
+    });
+  });
+
+  it('attaches an existing file to a container', async () => {
+    const response = await fetch(`${baseUrl}/api/containers/container_123/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fileId: 'file_123' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(containerFilesCreateMock).toHaveBeenCalledWith('container_123', { file_id: 'file_123' });
+  });
+
+  it('uploads new content to a container', async () => {
+    const toFileSpy = vi.spyOn(OpenAI, 'toFile').mockResolvedValue('upload-token' as never);
+
+    try {
+      const response = await fetch(`${baseUrl}/api/containers/container_123/files`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          filename: 'data.txt',
+          content: Buffer.from('container content').toString('base64'),
+          mimeType: 'text/plain',
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(containerFilesCreateMock).toHaveBeenCalledWith('container_123', { file: 'upload-token' });
+    } finally {
+      toFileSpy.mockRestore();
+    }
+  });
+
+  it('retrieves a container file by id', async () => {
+    const response = await fetch(`${baseUrl}/api/containers/container_123/files/file_456`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(containerFilesRetrieveMock).toHaveBeenCalledWith('file_456', {
+      container_id: 'container_123',
+    });
+    expect(payload).toEqual({ id: 'container_file_123' });
+  });
+
+  it('returns container file content as base64 payload', async () => {
+    const response = await fetch(`${baseUrl}/api/containers/container_123/files/file_456/content`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(containerFilesContentRetrieveMock).toHaveBeenCalledWith('file_456', {
+      container_id: 'container_123',
+    });
+    expect(payload).toEqual({
+      id: 'file_456',
+      contentType: 'text/plain',
+      base64: Buffer.from('container-file').toString('base64'),
+    });
+  });
+
+  it('removes a file from a container', async () => {
+    const response = await fetch(`${baseUrl}/api/containers/container_123/files/file_456`, {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(204);
+    expect(containerFilesDeleteMock).toHaveBeenCalledWith('file_456', {
+      container_id: 'container_123',
+    });
+  });
+
+  it('creates a response request', async () => {
+    const response = await fetch(`${baseUrl}/api/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-test',
+        input: 'Hello',
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(responsesCreateMock).toHaveBeenCalledWith({
+      model: 'gpt-test',
+      input: 'Hello',
+      stream: false,
+    });
+  });
+
+  it('rejects streaming response creation requests', async () => {
+    const response = await fetch(`${baseUrl}/api/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-test',
+        input: 'Hello',
+        stream: true,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(responsesCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('retrieves a response by id with sanitized params', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/responses/resp_123?include=steps&include_obfuscation=true&starting_after=2`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(responsesRetrieveMock).toHaveBeenCalledWith('resp_123', {
+      stream: false,
+      include: ['steps'],
+      include_obfuscation: true,
+      starting_after: 2,
+    });
+  });
+
+  it('deletes a response by id', async () => {
+    const response = await fetch(`${baseUrl}/api/responses/resp_123`, {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(204);
+    expect(responsesDeleteMock).toHaveBeenCalledWith('resp_123');
+  });
+
+  it('cancels a response by id', async () => {
+    const response = await fetch(`${baseUrl}/api/responses/resp_123/cancel`, {
+      method: 'POST',
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responsesCancelMock).toHaveBeenCalledWith('resp_123');
+    expect(payload).toEqual({ id: 'resp_123', status: 'cancelled' });
+  });
+
+  it('lists response input items with sanitized params', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/responses/resp_123/input-items?include=metadata&order=desc&after=item_1&limit=4`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(responseInputItemsListMock).toHaveBeenCalledWith('resp_123', {
+      include: ['metadata'],
+      order: 'desc',
+      after: 'item_1',
+      limit: 4,
+    });
+  });
+});

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'lcov'],
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "@types/ws": "^8.5.10",
         "tslib": "^2.6.2",
         "tsx": "^4.7.1",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "vitest": "^3.2.4"
       }
     },
     "apps/frontend": {
@@ -865,6 +866,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -884,6 +895,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1011,6 +1029,131 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1220,6 +1363,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1309,6 +1462,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1336,6 +1499,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cliui": {
@@ -1553,6 +1743,16 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1659,6 +1859,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1759,6 +1966,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -1803,6 +2020,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/finalhandler": {
@@ -2088,6 +2323,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -2335,11 +2584,41 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pinia": {
       "version": "2.3.1",
@@ -2692,6 +2971,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2701,6 +2987,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2709,6 +3002,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2736,6 +3036,80 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -2904,6 +3278,54 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -3335,6 +3757,104 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -3419,6 +3939,23 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {


### PR DESCRIPTION
## Summary
- extract the Express application setup into a reusable `createApp` helper
- add Vitest integration tests covering the API root, health, files, containers, and responses routes

## Testing
- npm run test -w backend

------
https://chatgpt.com/codex/tasks/task_e_68da7c6754148321bd98792599bb971d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled real-time updates via WebSocket connections.
  - Improved reliability with graceful server shutdown.
  - More consistent error and 404 responses.

- Refactor
  - Centralized app initialization for uniform middleware, routing, and lifecycle management.

- Tests
  - Added comprehensive HTTP API and WebSocket integration tests covering health, files, containers, responses, and connection events.
  - Introduced test coverage reporting.

- Chores
  - Added a test runner and script to easily execute backend tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->