### PR TITLE
Add Playwright end-to-end tests for frontend navigation

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.6.8",
@@ -16,6 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "@playwright/test": "^1.44.1",
     "@vitejs/plugin-vue": "^5.0.4",
     "typescript": "^5.4.5",
     "vite": "^5.2.0",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30 * 1000,
+  expect: {
+    timeout: 5000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 120 * 1000,
+  },
+});

--- a/apps/frontend/tests/e2e/navigation.spec.ts
+++ b/apps/frontend/tests/e2e/navigation.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+const mockHealthResponse = {
+  status: 'ok',
+  uptimeMs: 125000,
+  timestamp: '2024-01-01T12:34:56.000Z',
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    class MockWebSocket {
+      private listeners: Record<string, ((event: unknown) => void)[]> = {};
+      public readyState = 1;
+      public url: string;
+
+      constructor(url: string) {
+        this.url = url;
+        setTimeout(() => {
+          this.dispatchEvent('open', new Event('open'));
+        }, 0);
+      }
+
+      addEventListener(type: string, listener: (event: unknown) => void) {
+        this.listeners[type] = this.listeners[type] ?? [];
+        this.listeners[type].push(listener);
+      }
+
+      removeEventListener(type: string, listener: (event: unknown) => void) {
+        const registered = this.listeners[type];
+        if (!registered) {
+          return;
+        }
+        const index = registered.indexOf(listener);
+        if (index >= 0) {
+          registered.splice(index, 1);
+        }
+      }
+
+      dispatchEvent(type: string, event: unknown) {
+        const registered = this.listeners[type];
+        if (!registered) {
+          return;
+        }
+        for (const listener of [...registered]) {
+          listener(event);
+        }
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = 3;
+        this.dispatchEvent('close', new Event('close'));
+      }
+    }
+
+    Object.defineProperty(window, 'WebSocket', {
+      configurable: true,
+      writable: true,
+      value: MockWebSocket,
+    });
+  });
+
+  await page.route('**/api/health', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockHealthResponse),
+    });
+  });
+});
+
+test('displays the dashboard with API health details', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { level: 1, name: 'Legendary Dollop' })).toBeVisible();
+  await expect(page.getByRole('heading', { level: 2, name: 'Dashboard' })).toBeVisible();
+
+  const statusPill = page.locator('.status-card .status-pill').first();
+  await expect(statusPill).toHaveText('ok');
+
+  await expect(page.getByText('Uptime: 2m 5s')).toBeVisible();
+  await expect(page.getByText('No response events received yet.', { exact: true })).toBeVisible();
+});
+
+test('navigates to the WebSocket test lab from the header', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('link', { name: 'WebSocket Test' }).click();
+  await expect(page).toHaveURL(/\/websocket-test$/);
+  await expect(page.getByRole('heading', { level: 2, name: 'WebSocket Test Lab' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Send 10 dummy events' })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "vue-router": "^4.3.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.44.1",
         "@types/node": "^20.11.30",
         "@vitejs/plugin-vue": "^5.0.4",
         "typescript": "^5.4.5",
@@ -546,6 +547,22 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.3",
@@ -2613,7 +2630,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2641,6 +2657,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -3178,7 +3241,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3227,7 +3289,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3870,7 +3931,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",
@@ -4021,7 +4081,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
## Summary
- add Playwright test tooling to the frontend workspace and expose npm scripts
- configure Playwright to launch the Vite dev server and run Chromium-based e2e checks
- cover dashboard health rendering and navigation to the WebSocket lab with new tests

## Testing
- npm run test:e2e -w frontend

------
https://chatgpt.com/codex/tasks/task_e_68dd6408a1908321bee00a41fc0d2ae1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Playwright-based end-to-end tests covering dashboard health display and navigation to the WebSocket Test Lab.
  * Configured Playwright runner with timeouts, reporters (CI-aware), browser project, tracing/video, and automatic dev server startup for tests.

* **Chores**
  * Added npm scripts: test and test:e2e to run Playwright.
  * Added @playwright/test as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->